### PR TITLE
supporting PropertyNamingStrategies + being backwards compatible

### DIFF
--- a/beanie-core/src/main/java/com/nosto/beanie/NamingStrategyTest.java
+++ b/beanie-core/src/main/java/com/nosto/beanie/NamingStrategyTest.java
@@ -32,18 +32,18 @@ public interface NamingStrategyTest<T> extends BeanieTest<T> {
     default void testNamingStrategy(Class<? extends T> concreteClass) {
         BeanDescription beanDescription = getDescription(concreteClass);
 
-        @SuppressWarnings("unchecked")
-        Optional<Class<? extends PropertyNamingStrategy>> maybeMapperNamingStrategy = Optional.ofNullable(getMapper().getPropertyNamingStrategy())
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Class<? extends PropertyNamingStrategy> configuredNamingStrategy = Optional.ofNullable(getMapper().getPropertyNamingStrategy())
                 .map(Object::getClass)
                 .map(clazz -> (Class<? extends PropertyNamingStrategy>) clazz)
-                .map(NamingStrategyTest::getNamingStrategy);
-        Class<? extends PropertyNamingStrategy> configuredNamingStrategy = maybeMapperNamingStrategy.orElse(PropertyNamingStrategies.LowerCamelCaseStrategy.class);
+                .map(NamingStrategyTest::getNamingStrategy)
+                .orElse((Class) PropertyNamingStrategies.LowerCamelCaseStrategy.class);
 
-        Optional<Class<? extends PropertyNamingStrategy>> maybeAnnotationNamingStrategy = Optional.ofNullable(beanDescription.getClassAnnotations().get(JsonNaming.class))
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Class<? extends PropertyNamingStrategy> beanPropertyNamingStrategy = Optional.ofNullable(beanDescription.getClassAnnotations().get(JsonNaming.class))
                 .map(JsonNaming::value)
-                .map(NamingStrategyTest::getNamingStrategy);
-        Class<? extends PropertyNamingStrategy> beanPropertyNamingStrategy = maybeAnnotationNamingStrategy
-                .orElse(configuredNamingStrategy);
+                .map(NamingStrategyTest::getNamingStrategy)
+                .orElse((Class)configuredNamingStrategy);
 
         Map<Class<? extends PropertyNamingStrategy>, List<String>> cases = beanDescription.findProperties()
                 .stream()

--- a/beanie-core/src/main/java/com/nosto/beanie/NamingStrategyTest.java
+++ b/beanie-core/src/main/java/com/nosto/beanie/NamingStrategyTest.java
@@ -9,22 +9,17 @@
  */
 package com.nosto.beanie;
 
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.KebabCaseStrategy;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.LowerCamelCaseStrategy;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.LowerCaseStrategy;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.LowerDotCaseStrategy;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.UpperCamelCaseStrategy;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 
 public interface NamingStrategyTest<T> extends BeanieTest<T> {
 
@@ -50,7 +45,7 @@ public interface NamingStrategyTest<T> extends BeanieTest<T> {
                 .map(JsonNaming::value)
                 .map(NamingStrategyTest::getNamingStrategy)
                 // Required to get around compilation error
-                .map(s -> (Class<PropertyNamingStrategy>) s)
+                .map(klass -> (Class<PropertyNamingStrategy>) klass)
                 .orElse(configuredNamingStrategy);
 
         Map<Class<PropertyNamingStrategy>, List<String>> cases = beanDescription.findProperties()
@@ -60,14 +55,14 @@ public interface NamingStrategyTest<T> extends BeanieTest<T> {
                     if (name.contains("_") && name.toLowerCase().equals(name)) {
                         // Required to get around compilation error
                         //noinspection unchecked
-                        return (Class<PropertyNamingStrategy>) PropertyNamingStrategy.SNAKE_CASE.getClass();
+                        return (Class<PropertyNamingStrategy>) PropertyNamingStrategies.SNAKE_CASE.getClass();
                     } else if (name.toLowerCase().equals(name)) {
                         // Could be snake case or camel case, so let's assume the class's naming strategy.
                         return beanPropertyNamingStrategy;
                     } else {
                         // Required to get around compilation error
                         //noinspection unchecked
-                        return (Class<PropertyNamingStrategy>) PropertyNamingStrategy.LOWER_CAMEL_CASE.getClass();
+                        return (Class<PropertyNamingStrategy>) PropertyNamingStrategies.LOWER_CAMEL_CASE.getClass();
                     }
                 }));
         assertEquals(1, cases.size(), cases.toString());
@@ -81,23 +76,23 @@ public interface NamingStrategyTest<T> extends BeanieTest<T> {
     }
 
     private static Class<?> getNamingStrategy(Class<?> namingStrategy) {
-        if (namingStrategy.equals(LowerCamelCaseStrategy.class)) {
-            return PropertyNamingStrategy.LOWER_CAMEL_CASE.getClass();
+        if (namingStrategy.equals(PropertyNamingStrategy.class)) {
+            return PropertyNamingStrategies.LOWER_CAMEL_CASE.getClass();
         }
-        if (namingStrategy.equals(UpperCamelCaseStrategy.class)) {
-            return PropertyNamingStrategy.UPPER_CAMEL_CASE.getClass();
+        if (namingStrategy.equals(PropertyNamingStrategy.UpperCamelCaseStrategy.class)) {
+            return PropertyNamingStrategies.UPPER_CAMEL_CASE.getClass();
         }
-        if (namingStrategy.equals(SnakeCaseStrategy.class)) {
-            return PropertyNamingStrategy.SNAKE_CASE.getClass();
+        if (namingStrategy.equals(PropertyNamingStrategy.SnakeCaseStrategy.class)) {
+            return PropertyNamingStrategies.SNAKE_CASE.getClass();
         }
-        if (namingStrategy.equals(LowerCaseStrategy.class)) {
-            return PropertyNamingStrategy.LOWER_CASE.getClass();
+        if (namingStrategy.equals(PropertyNamingStrategy.LowerCaseStrategy.class)) {
+            return PropertyNamingStrategies.LOWER_CASE.getClass();
         }
-        if (namingStrategy.equals(KebabCaseStrategy.class)) {
-            return PropertyNamingStrategy.KEBAB_CASE.getClass();
+        if (namingStrategy.equals(PropertyNamingStrategy.KebabCaseStrategy.class)) {
+            return PropertyNamingStrategies.KEBAB_CASE.getClass();
         }
-        if (namingStrategy.equals(LowerDotCaseStrategy.class)) {
-            return PropertyNamingStrategy.LOWER_DOT_CASE.getClass();
+        if (namingStrategy.equals(PropertyNamingStrategy.LowerDotCaseStrategy.class)) {
+            return PropertyNamingStrategies.LOWER_DOT_CASE.getClass();
         }
         return namingStrategy;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects { project ->
     apply plugin: "com.dorongold.task-tree"
 
     group 'com.nosto.beanie'
-    version '3.2.0-SNAPSHOT-1725965455164'
+    version '3.2.0-SNAPSHOT-1726839582133'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Description
Supporting Jackson versions newer than 2.14 (supporting "new" `PropertyNamingStrategies`)

## Motivation and Context
Need to upgrade Playcart's Jackson, for which Beanie needs to be updated to support the new Jackson classes (or the tests fail when they shouldn't)

## Related Jira ticket
[HEALTH-1037](https://nostosolutions.atlassian.net/browse/HEALTH-1037)
[HEALTH-1038](https://nostosolutions.atlassian.net/browse/HEALTH-1038)

## Testing
Not really

## Documentation
Not really

## Checklist
- [x] Pull Request is properly described.
- [x] The corresponding Jira ticket is updated.
- [x] I have requested a review from at least one reviewer.
- [x] The changes are tested
- ~[ ] I have verified my UX changes with a designer~
- ~[ ] I have checked my code for any possible security vulnerabilities~

## Screenshots
Not really

[HEALTH-1037]: https://nostosolutions.atlassian.net/browse/HEALTH-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HEALTH-1038]: https://nostosolutions.atlassian.net/browse/HEALTH-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ